### PR TITLE
chore: Removed duplicate AerisDemoSupport in Target Dependencies

### DIFF
--- a/Demo/AerisDemo.xcodeproj/project.pbxproj
+++ b/Demo/AerisDemo.xcodeproj/project.pbxproj
@@ -184,13 +184,6 @@
 			remoteGlobalIDString = 2BD7690C1FF4127A00F758C9;
 			remoteInfo = AerisDemoSupport;
 		};
-		2BF105F61FF565BA005BFBA4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 2BD769931FF4141100F758C9 /* AerisDemoSupport.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 2BD7690B1FF4127A00F758C9;
-			remoteInfo = AerisDemoSupport;
-		};
 		2BF105F81FF565EC005BFBA4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 2BD769931FF4141100F758C9 /* AerisDemoSupport.xcodeproj */;
@@ -884,7 +877,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				2BF105F71FF565BA005BFBA4 /* PBXTargetDependency */,
 				2BF107171FF58F7A005BFBA4 /* PBXTargetDependency */,
 			);
 			name = AerisObjCDemo;
@@ -1318,11 +1310,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		2BF105F71FF565BA005BFBA4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AerisDemoSupport;
-			targetProxy = 2BF105F61FF565BA005BFBA4 /* PBXContainerItemProxy */;
-		};
 		2BF105F91FF565EC005BFBA4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AerisDemoSupport;


### PR DESCRIPTION
chore: Removed duplicate AerisDemoSupport in Target Dependencies

The AerisObjCDemo target had accrued a 2nd AerisDemoSupport framework in its Target Dependencies— not an uncommon occurrence since Xcode adds this automatically

* Removed duplicate AerisDemoSupport framework in AerisObjCDemo's Target Dependencies.  
	‣ Made sure to delete the one that wasn't being used for other stuff, e.g. Embed Frameworks.
