### PR TITLE
fix: Indices loading correct data & updating UI when Type is changed

### DIFF
--- a/Demo/AerisObjCDemo/Source/IndicesViewController.m
+++ b/Demo/AerisObjCDemo/Source/IndicesViewController.m
@@ -215,6 +215,9 @@
 
 - (void)optionsViewControllerDidChangeSelectedOption:(UIViewController *)optionsViewController {
 	self.currentIndexType = ((IndicesOptionsViewController *)optionsViewController).selectedIndexType;
+	if (self.currentIndexType != self.dataLastIndexType) {
+		[self loadDataForDefaultPlace];
+	}
 }
 
 #pragma mark - Private Methods


### PR DESCRIPTION
In the Indices view (`IndicesViewController`) when the Type button was used to change the `currentIndexType`, updated data was not being reloaded from the endpoint and the `UITableView`'s cells weren't being told to refresh (they would refresh when they go off-screen, but only superficially look like they updates since they were still using data from the previous `currentIndexType`).

* Fix: In `IndicesViewController`'s `- optionsViewControllerDidChangeSelectedOption:`, now calling `- loadDataForDefaultPlace` _(which causes `self.results` and `self.dataLastIndexType` to be updated, and the `UITableView to `reloadData`)_.