### PR TITLE
chore: Added `#import <Foundation/Foundation.h>` to NS-using headers

### DIFF
--- a/Demo/AerisDemoSupport/AerisDemoSupport/AerisDemoSupport.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/AerisDemoSupport.h
@@ -6,6 +6,7 @@
 //  Copyright © 2017 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 //! Project version number for AerisDemoSupport.

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/Preferences.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/Preferences.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "PAPreferences.h"
 #import "AWFCascadingStyle.h"
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/UserLocationsManager.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/UserLocationsManager.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "Globals.h"
 
 @class AWFPlace;

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/GroupedTableViewCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/GroupedTableViewCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface GroupedTableViewCell : UITableViewCell

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/ListingEventView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/ListingEventView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "Globals.h"
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/ListingTableViewCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/ListingTableViewCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 @import UIKit;
 
 @interface ListingTableViewCell : UITableViewCell

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/MultilineTextTableViewCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/Views/MultilineTextTableViewCell.h
@@ -6,6 +6,7 @@
 //  Copyright © 2015 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "Globals.h"
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFAdvisoryStyle.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFAdvisoryStyle.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "AWFCascadingStyle.h"
 
 @interface AWFAdvisoryStyle : AWFCascadingStyle

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFCascadingStyle.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFCascadingStyle.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "Globals.h"
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFLegacyStyle.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFLegacyStyle.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "AWFCascadingStyle.h"
 
 /**

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFStyledHeaderView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFStyledHeaderView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "AWFStyledView.h"
 
 /**

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFStyledView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/AWFStyledView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "Globals.h"
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFAdvisoryDetailView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFAdvisoryDetailView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFCollectionViewHourlyBasicCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFCollectionViewHourlyBasicCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 @import UIKit;
 
 @class AWFHourlyBasicView;

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFDailySummaryView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFDailySummaryView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisWeatherKit/AerisWeatherKit.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFForecastDetailView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFForecastDetailView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 
 @interface AWFForecastDetailView : AWFStyledView

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFHourlyBasicView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFHourlyBasicView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 
 @interface AWFHourlyBasicView : AWFStyledView

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFObservationAdvisoriesView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFObservationAdvisoriesView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 
 @class AWFStyledHeaderView;

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFObservationView.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFObservationView.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 
 @interface AWFObservationView : AWFStyledView

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewDailySummaryCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewDailySummaryCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 @import UIKit;
 
 @class AWFDailySummaryView;

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewForecast24HourCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewForecast24HourCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewForecastRowCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewForecastRowCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewObservationRowCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewObservationRowCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import <AerisDemoSupport/AWFStyledView.h>
 

--- a/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewObservationRowCityCell.h
+++ b/Demo/AerisDemoSupport/AerisDemoSupport/Source/WeatherUI/Views/AWFTableViewObservationRowCityCell.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "AWFStyledView.h"
 

--- a/Demo/AerisObjCDemo/Source/AdvisoriesViewController.h
+++ b/Demo/AerisObjCDemo/Source/AdvisoriesViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface AdvisoriesViewController : UIViewController

--- a/Demo/AerisObjCDemo/Source/AppDelegate.h
+++ b/Demo/AerisObjCDemo/Source/AppDelegate.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 @import UIKit;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>

--- a/Demo/AerisObjCDemo/Source/CatalogViewController.h
+++ b/Demo/AerisObjCDemo/Source/CatalogViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @protocol CatalogViewControllerDelegate;

--- a/Demo/AerisObjCDemo/Source/ConvectiveOutlookViewController.h
+++ b/Demo/AerisObjCDemo/Source/ConvectiveOutlookViewController.h
@@ -6,6 +6,7 @@
 //  Copyright © 2015 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface ConvectiveOutlookViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/DailySummariesViewController.h
+++ b/Demo/AerisObjCDemo/Source/DailySummariesViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface DailySummariesViewController : UIViewController

--- a/Demo/AerisObjCDemo/Source/DailySummaryGraphsViewController.h
+++ b/Demo/AerisObjCDemo/Source/DailySummaryGraphsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface DailySummaryGraphsViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/Devices/iPad/BarGraphsViewController_iPad.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPad/BarGraphsViewController_iPad.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ForecastBarGraphsViewController.h"
 
 @interface BarGraphsViewController_iPad : ForecastBarGraphsViewController

--- a/Demo/AerisObjCDemo/Source/Devices/iPad/DetailedWeatherViewController_iPad.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPad/DetailedWeatherViewController_iPad.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "CatalogViewController.h"
 
 @interface DetailedWeatherViewController_iPad : UIViewController <UISplitViewControllerDelegate, CatalogViewControllerDelegate>

--- a/Demo/AerisObjCDemo/Source/Devices/iPad/LineGraphsViewController_iPad.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPad/LineGraphsViewController_iPad.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ForecastLineGraphsViewController.h"
 
 @interface LineGraphsViewController_iPad : ForecastLineGraphsViewController

--- a/Demo/AerisObjCDemo/Source/Devices/iPad/ModelGraphsViewController_iPad.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPad/ModelGraphsViewController_iPad.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ModelGraphsViewController.h"
 
 @interface ModelGraphsViewController_iPad : ModelGraphsViewController

--- a/Demo/AerisObjCDemo/Source/Devices/iPhone/DetailedWeatherViewController.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPhone/DetailedWeatherViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface DetailedWeatherViewController : UIViewController <UICollectionViewDataSource, UICollectionViewDelegate>

--- a/Demo/AerisObjCDemo/Source/Devices/iPhone/ForecastBarGraphsViewController.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPhone/ForecastBarGraphsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface ForecastBarGraphsViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/Devices/iPhone/ForecastLineGraphsViewController.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPhone/ForecastLineGraphsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface ForecastLineGraphsViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/Devices/iPhone/ModelGraphsViewController.h
+++ b/Demo/AerisObjCDemo/Source/Devices/iPhone/ModelGraphsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface ModelGraphsViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/DroughtMonitorViewController.h
+++ b/Demo/AerisObjCDemo/Source/DroughtMonitorViewController.h
@@ -6,6 +6,7 @@
 //  Copyright © 2015 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface DroughtMonitorViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/EarthquakesViewController.h
+++ b/Demo/AerisObjCDemo/Source/EarthquakesViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ListingViewController.h"
 
 @interface EarthquakesViewController : ListingViewController

--- a/Demo/AerisObjCDemo/Source/ForecastViewController.h
+++ b/Demo/AerisObjCDemo/Source/ForecastViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface ForecastViewController : UIViewController

--- a/Demo/AerisObjCDemo/Source/Graphs/BarGraphsViewController.h
+++ b/Demo/AerisObjCDemo/Source/Graphs/BarGraphsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface BarGraphsViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/Graphs/GraphViewController.h
+++ b/Demo/AerisObjCDemo/Source/Graphs/GraphViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @class GraphViewController;

--- a/Demo/AerisObjCDemo/Source/Graphs/LineGraphsViewController.h
+++ b/Demo/AerisObjCDemo/Source/Graphs/LineGraphsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface LineGraphsViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/GroupedListingViewController.h
+++ b/Demo/AerisObjCDemo/Source/GroupedListingViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ListingViewController.h"
 
 @interface GroupedListingViewController : ListingViewController

--- a/Demo/AerisObjCDemo/Source/IndicesViewController.h
+++ b/Demo/AerisObjCDemo/Source/IndicesViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @protocol OptionsViewControllerDelegate;

--- a/Demo/AerisObjCDemo/Source/ListingViewController.h
+++ b/Demo/AerisObjCDemo/Source/ListingViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @class ListingEventView;

--- a/Demo/AerisObjCDemo/Source/LocationSearchViewController.h
+++ b/Demo/AerisObjCDemo/Source/LocationSearchViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 extern NSString * const kAWFDemoDefaultPlaceChanged;

--- a/Demo/AerisObjCDemo/Source/Maps/AppleMapViewController.h
+++ b/Demo/AerisObjCDemo/Source/Maps/AppleMapViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "MapViewController.h"
 
 @interface AppleMapViewController : MapViewController

--- a/Demo/AerisObjCDemo/Source/Maps/GoogleMapViewController.h
+++ b/Demo/AerisObjCDemo/Source/Maps/GoogleMapViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "MapViewController.h"
 
 @interface GoogleMapViewController : MapViewController

--- a/Demo/AerisObjCDemo/Source/Maps/MapViewController.h
+++ b/Demo/AerisObjCDemo/Source/Maps/MapViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisMapKit/AerisMapKit.h>
 
 @interface MapViewController : AWFWeatherMapViewController

--- a/Demo/AerisObjCDemo/Source/Maps/MapboxMapViewController.h
+++ b/Demo/AerisObjCDemo/Source/Maps/MapboxMapViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <AerisMapboxMapKit/AerisMapboxMapKit.h>
 #import "MapViewController.h"
 

--- a/Demo/AerisObjCDemo/Source/MoonPhasesViewController.h
+++ b/Demo/AerisObjCDemo/Source/MoonPhasesViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface MoonPhasesViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/NearbyObservationsViewController.h
+++ b/Demo/AerisObjCDemo/Source/NearbyObservationsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface NearbyObservationsViewController : UIViewController

--- a/Demo/AerisObjCDemo/Source/NormalsViewController.h
+++ b/Demo/AerisObjCDemo/Source/NormalsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface NormalsViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/RecentObsGraphViewController.h
+++ b/Demo/AerisObjCDemo/Source/RecentObsGraphViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GraphViewController.h"
 
 @interface RecentObsGraphViewController : GraphViewController

--- a/Demo/AerisObjCDemo/Source/RecentObservationsViewController.h
+++ b/Demo/AerisObjCDemo/Source/RecentObservationsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface RecentObservationsViewController : UIViewController

--- a/Demo/AerisObjCDemo/Source/RecordsViewController.h
+++ b/Demo/AerisObjCDemo/Source/RecordsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ListingViewController.h"
 
 @interface RecordsViewController : ListingViewController

--- a/Demo/AerisObjCDemo/Source/SettingsViewController.h
+++ b/Demo/AerisObjCDemo/Source/SettingsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface SettingsViewController : UIViewController

--- a/Demo/AerisObjCDemo/Source/StormCellsViewController.h
+++ b/Demo/AerisObjCDemo/Source/StormCellsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ListingViewController.h"
 
 @interface StormCellsViewController : ListingViewController

--- a/Demo/AerisObjCDemo/Source/StormReportsViewController.h
+++ b/Demo/AerisObjCDemo/Source/StormReportsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "ListingViewController.h"
 
 @interface StormReportsViewController : ListingViewController

--- a/Demo/AerisObjCDemo/Source/SunMoonViewController.h
+++ b/Demo/AerisObjCDemo/Source/SunMoonViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface SunMoonViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/ThreatsViewController.h
+++ b/Demo/AerisObjCDemo/Source/ThreatsViewController.h
@@ -6,6 +6,7 @@
 //  Copyright © 2015 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface ThreatsViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/TidesViewController.h
+++ b/Demo/AerisObjCDemo/Source/TidesViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import "GroupedListingViewController.h"
 
 @interface TidesViewController : GroupedListingViewController

--- a/Demo/AerisObjCDemo/Source/WeekendWeatherViewController.h
+++ b/Demo/AerisObjCDemo/Source/WeekendWeatherViewController.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2013 HAMweather, LLC. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
 @interface WeekendWeatherViewController : UIViewController


### PR DESCRIPTION
The main initiative for this addition is to help Xcode's Swift generated interface assistant, Swift documentation window & popovers, code completions, and debugger to all display correct info about these Obj-C classes.  The issues I was seeing was Obj-C types being misinterpreted _(e.g. `BOOL` was becoming `Int32` instead of `Bool`)_, method & property names weren't being Swift-ified _(per name translation rules at https://github.com/apple/swift/blob/main/docs/CToSwiftNameTranslation.md )_, and occasionally no Swift-generated output at all.  To be clear, everything was compiling fine, so this is all in aid of Xcode's previews/docs— it seems Xcode is a bit more picky about this than `clang`/`swiftc`.

AFAICT, this a good-practice choice given a few validations:

* All Apple sample code and WWDC video code does this, and a lot of the Obj-C code I've seen over the years also does.
* Most header files are directly using stuff from Foundation— if not `NSObject` or `NSArray`, modern Obj-C headers are likely going to use the macros `NS_ASSUME_NONNULL_BEGIN`/`END` (or the newer `NS_HEADER_AUDIT_BEGIN`/`END`), or `NS_ENUM`/`OPTIONS`/etc., or `FOUNDATION_EXPORT`, which all come from Foundation.
* In C-style languages there's an old “good practice” to include (or forward declare) everything you're directly using in your file, instead of counting on included files you don't control to include the thing you need.
* And most importantly, this is what Apple does with their Obj-C frameworks— almost every header under `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks/*.framework/Headers/*.h` follows this practice.  
	‣ The major exceptions to this in Apple's frameworks seem to be stuff that's CoreFoundation-based instead, that only use specific macros (such as those found in `<TargetConditionals.h>`, `<Availability.h>`, `<AvailabilityMacros.h>`), that has its own Foundation-like types (such as `ARKitFoundation.h`), or that is C/C++-based instead of Obj-C (such as Spatial framework).

## Changes:

* Added explicit `#import <Foundation/Foundation.h>` as the 1st import in all headers that use anything from Foundation— which comes out to more-or-less any class, any protocol, any macro, & any constant that starts with `NS…`.  
	‣ This includes files that already import something that imports Foundation, such as UIKit.
	‣ Excluding header files that just include other headers, or just define constants/macros/structs that aren't dependent on Foundation-derived stuff.
	* Also added to standard Obj-C class headers, for consistency _(even if they don't explicitly mention `NS…` stuff)_.  
		‣ There's a high likelihood they could gain a `NS_ASSUME_NONNULL_BEGIN`/`END` annotation in the future.