### PR TITLE
fix: Set apps' Appearance to Light

### DIFF
--- a/Demo/AerisObjCDemo/Info.plist
+++ b/Demo/AerisObjCDemo/Info.plist
@@ -59,5 +59,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/Demo/AerisSwiftDemo/Info.plist
+++ b/Demo/AerisSwiftDemo/Info.plist
@@ -34,5 +34,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
* Set Appearance (UIUserInterfaceStyle): Light in the `Info.plist`s.  
	‣ The views haven't been fully updated for dark mode yet, so this makes things look correct until they have been updated.